### PR TITLE
Flatten headers array before mapping to the result (fixes #3)

### DIFF
--- a/src/WebDAVAdapter.php
+++ b/src/WebDAVAdapter.php
@@ -87,12 +87,12 @@ class WebDAVAdapter extends AbstractAdapter
             if ($response['statusCode'] !== 200) {
                 return false;
             }
-
+            $headers = array_map(function ($el) { return join(',', $el); }, $response['headers']);
             return array_merge([
                 'contents' => $response['body'],
-                'timestamp' => strtotime($response['headers']['last-modified']),
+                'timestamp' => strtotime($headers['last-modified']),
                 'path' => $path,
-            ], Util::map($response['headers'], static::$resultMap));
+            ], Util::map($headers, static::$resultMap));
         } catch (Exception\FileNotFound $e) {
             return false;
         }

--- a/tests/WebDAVTests.php
+++ b/tests/WebDAVTests.php
@@ -65,7 +65,7 @@ class WebDAVTests extends PHPUnit_Framework_TestCase
             'statusCode' => 200,
             'body' => 'contents',
             'headers' => [
-                'last-modified' => date('Y-m-d H:i:s'),
+                'last-modified' => [ date('Y-m-d H:i:s') ],
             ],
         ]);
         $adapter = new WebDAVAdapter($mock, 'bucketname', 'prefix');
@@ -203,7 +203,7 @@ class WebDAVTests extends PHPUnit_Framework_TestCase
             'statusCode' => 200,
             'body' => 'contents',
             'headers' => [
-                'last-modified' => date('Y-m-d H:i:s'),
+                'last-modified' => [ date('Y-m-d H:i:s') ],
             ],
         ]);
         $adapter = new WebDAVAdapter($mock, 'bucketname', 'prefix');
@@ -218,7 +218,7 @@ class WebDAVTests extends PHPUnit_Framework_TestCase
             'statusCode' => 404,
             'body' => 'contents',
             'headers' => [
-                'last-modified' => date('Y-m-d H:i:s'),
+                'last-modified' => [ date('Y-m-d H:i:s') ],
             ],
         ]);
         $adapter = new WebDAVAdapter($mock, 'bucketname', 'prefix');
@@ -233,7 +233,7 @@ class WebDAVTests extends PHPUnit_Framework_TestCase
             'statusCode' => 404,
             'body' => 'contents',
             'headers' => [
-                'last-modified' => date('Y-m-d H:i:s'),
+                'last-modified' => [ date('Y-m-d H:i:s') ],
             ],
         ]);
         $adapter = new WebDAVAdapter($mock, 'bucketname', 'prefix');


### PR DESCRIPTION
As described in the commit, this pull request fixes issue #3 (Last modified date is an array). 

The test is also updated.