### PR TITLE
Fix exception catch

### DIFF
--- a/src/WebDAVAdapter.php
+++ b/src/WebDAVAdapter.php
@@ -11,6 +11,7 @@ use League\Flysystem\Util;
 use LogicException;
 use Sabre\DAV\Client;
 use Sabre\DAV\Exception;
+use Sabre\DAV\Exception\NotFound;
 
 class WebDAVAdapter extends AbstractAdapter
 {
@@ -93,7 +94,7 @@ class WebDAVAdapter extends AbstractAdapter
                 'timestamp' => strtotime($response['headers']['last-modified']),
                 'path' => $path,
             ], Util::map($response['headers'], static::$resultMap));
-        } catch (Exception\FileNotFound $e) {
+        } catch (Exception $e) {
             return false;
         }
     }
@@ -138,7 +139,7 @@ class WebDAVAdapter extends AbstractAdapter
             if ($response['statusCode'] >= 200 && $response['statusCode'] < 300) {
                 return true;
             }
-        } catch (Exception\FileNotFound $e) {
+        } catch (NotFound $e) {
             // Would have returned false here, but would be redundant
         }
 
@@ -156,7 +157,7 @@ class WebDAVAdapter extends AbstractAdapter
             $this->client->request('DELETE', $location);
 
             return true;
-        } catch (Exception\FileNotFound $e) {
+        } catch (NotFound $e) {
             return false;
         }
     }

--- a/src/WebDAVAdapter.php
+++ b/src/WebDAVAdapter.php
@@ -62,7 +62,7 @@ class WebDAVAdapter extends AbstractAdapter
             ]);
 
             return $this->normalizeObject($result, $path);
-        } catch (Exception\FileNotFound $e) {
+        } catch (Exception $e) {
             return false;
         }
     }

--- a/src/WebDAVAdapter.php
+++ b/src/WebDAVAdapter.php
@@ -91,7 +91,7 @@ class WebDAVAdapter extends AbstractAdapter
 
             return array_merge([
                 'contents' => $response['body'],
-                'timestamp' => strtotime($response['headers']['last-modified']),
+                'timestamp' => strtotime(is_array($response['headers']['last-modified'])?current($response['headers']['last-modified']):$response['headers']['last-modified']),
                 'path' => $path,
             ], Util::map($response['headers'], static::$resultMap));
         } catch (Exception $e) {


### PR DESCRIPTION
In sabre/dav package the class DAV\Client.php throw a Sabre\DAV\Exception line 236 in case of an http status > 400
```php
    function propFind($url, array $properties, $depth = 0) {

//...
$request = new HTTP\Request('PROPFIND', $url, [
            'Depth' => $depth,
            'Content-Type' => 'application/xml'
        ], $body);

        $response = $this->send($request);

        if ((int)$response->getStatus() >= 400) {
            throw new Exception('HTTP error: ' . $response->getStatus());
        }
//...
}
```
Remove deprecated FileNotFound exception
```php
/**
 * FileNotFound
 *
 * Deprecated: Warning, this class is deprecated and will be removed in a
 * future version of SabreDAV. Please use Sabre\DAV\Exception\NotFound instead.
 *
 * @copyright Copyright (C) 2007-2015 fruux GmbH (https://fruux.com/).
 * @author Evert Pot (http://evertpot.com/)
 * @deprecated Use Sabre\DAV\Exception\NotFound instead
 * @license http://sabre.io/license/ Modified BSD License
 */

```
