### PR TITLE
Fix write errors being silently ignored

### DIFF
--- a/src/WebDAVAdapter.php
+++ b/src/WebDAVAdapter.php
@@ -107,7 +107,12 @@ class WebDAVAdapter extends AbstractAdapter
     public function write($path, $contents, Config $config)
     {
         $location = $this->applyPathPrefix($path);
-        $this->client->request('PUT', $location, $contents);
+        $response = $this->client->request('PUT', $location, $contents);
+
+        if ($response['statusCode'] >= 400) {
+            return false;
+        }
+
         $result = compact('path', 'contents');
 
         if ($config->get('visibility')) {

--- a/tests/WebDAVTests.php
+++ b/tests/WebDAVTests.php
@@ -32,9 +32,22 @@ class WebDAVTests extends PHPUnit_Framework_TestCase
     public function testWrite()
     {
         $mock = $this->getClient();
-        $mock->shouldReceive('request')->once();
+        $mock->shouldReceive('request')->once()->andReturn([
+            'statusCode' => 200,
+        ]);
         $adapter = new WebDAVAdapter($mock);
         $this->assertInternalType('array', $adapter->write('something', 'something', new Config()));
+    }
+
+    public function testWriteFail()
+    {
+        $mock = $this->getClient();
+        $mock->shouldReceive('request')->with('PUT', 'something', 'something')->once()->andReturn([
+            'statusCode' => 500,
+        ]);
+        $adapter = new WebDAVAdapter($mock);
+        $result = $adapter->write('something', 'something', new Config());
+        $this->assertFalse($result);
     }
 
     public function testUpdate()
@@ -51,7 +64,9 @@ class WebDAVTests extends PHPUnit_Framework_TestCase
     public function testWriteVisibility()
     {
         $mock = $this->getClient();
-        $mock->shouldReceive('request')->once();
+        $mock->shouldReceive('request')->once()->andReturn([
+            'statusCode' => 200,
+        ]);
         $adapter = new WebDAVAdapter($mock);
         $this->assertInternalType('array', $adapter->write('something', 'something', new Config([
             'visibility' => 'private',


### PR DESCRIPTION
The current implementation of the `write()` method does not handle failed requests and never returns `false` for status codes >= 400, as it is supposed to do:

```php
public function write($path, $contents, Config $config)
{
    $location = $this->applyPathPrefix($path);
    $this->client->request('PUT', $location, $contents);
    $result = compact('path', 'contents');

    if ($config->get('visibility')) {
        throw new LogicException(__CLASS__.' does not support visibility settings.');
    }

    return $result;
}
```

The response from the client request is silently discarded.

This patch adds the missing status code check and the corresponding tests.

