### PR TITLE
Support path with spaces

### DIFF
--- a/src/WebDAVAdapter.php
+++ b/src/WebDAVAdapter.php
@@ -270,4 +270,15 @@ class WebDAVAdapter extends AbstractAdapter
 
         return $result;
     }
+
+    /**
+     * @param string $path
+     * @return string
+     */
+    public function applyPathPrefix($path)
+    {
+        $pathWithPrefix = parent::applyPathPrefix($path);
+
+        return str_replace(' ', '%20', $pathWithPrefix);
+    }
 }

--- a/tests/WebDAVTests.php
+++ b/tests/WebDAVTests.php
@@ -6,6 +6,9 @@ use League\Flysystem\WebDAV\WebDAVAdapter;
 
 class WebDAVTests extends PHPUnit_Framework_TestCase
 {
+    /**
+     * @return \Mockery\MockInterface|\Sabre\DAV\Client
+     */
     protected function getClient()
     {
         return Mockery::mock('Sabre\DAV\Client');
@@ -197,6 +200,17 @@ class WebDAVTests extends PHPUnit_Framework_TestCase
         ]);
         $adapter = new WebDAVAdapter($mock);
         $result = $adapter->createDir('dirname', new Config());
+        $this->assertInternalType('array', $result);
+    }
+
+    public function testCreateDirWhichContainsSpaces()
+    {
+        $mock = $this->getClient();
+        $mock->shouldReceive('request')->with('MKCOL', 'dirname%20with%20spaces')->once()->andReturn([
+            'statusCode' => 201,
+        ]);
+        $adapter = new WebDAVAdapter($mock);
+        $result = $adapter->createDir('dirname with spaces', new Config());
         $this->assertInternalType('array', $result);
     }
 


### PR DESCRIPTION
File/directory name is cut if it contains a space. E.g. if I store file "my file.txt", it will end up that file with name "my" is stored.