### PR TITLE
Convert url encoding

### DIFF
--- a/src/WebDAVAdapter.php
+++ b/src/WebDAVAdapter.php
@@ -13,7 +13,7 @@ use Sabre\DAV\Client;
 use Sabre\DAV\Exception;
 use Sabre\DAV\Exception\NotFound;
 
-class WebDAVAdapter extends AbstractAdapter
+class WebDAVAdapterx extends AbstractAdapter
 {
     use StreamedTrait;
     use StreamedCopyTrait;
@@ -47,11 +47,27 @@ class WebDAVAdapter extends AbstractAdapter
     }
 
     /**
+     * url encode a path
+     *
+     * @param string $path
+     *
+     * @return string
+     */
+    protected function encodePath($path)
+	{
+		$a = explode('/', $path);
+		for ($i=0; $i<count($a); $i++) {
+			$a[$i] = rawurlencode($a[$i]);
+		}
+		return implode('/', $a);
+	}
+	
+    /**
      * {@inheritdoc}
      */
     public function getMetadata($path)
     {
-        $location = $this->applyPathPrefix($path);
+        $location = $this->applyPathPrefix($this->encodePath($path));
 
         try {
             $result = $this->client->propFind($location, [
@@ -80,7 +96,7 @@ class WebDAVAdapter extends AbstractAdapter
      */
     public function read($path)
     {
-        $location = $this->applyPathPrefix($path);
+        $location = $this->applyPathPrefix($this->encodePath($path));
 
         try {
             $response = $this->client->request('GET', $location);
@@ -106,7 +122,7 @@ class WebDAVAdapter extends AbstractAdapter
      */
     public function write($path, $contents, Config $config)
     {
-        $location = $this->applyPathPrefix($path);
+        $location = $this->applyPathPrefix($this->encodePath($path));
         $response = $this->client->request('PUT', $location, $contents);
 
         if ($response['statusCode'] >= 400) {
@@ -135,8 +151,8 @@ class WebDAVAdapter extends AbstractAdapter
      */
     public function rename($path, $newpath)
     {
-        $location = $this->applyPathPrefix($path);
-        $newLocation = $this->applyPathPrefix($newpath);
+        $location = $this->applyPathPrefix($this->encodePath($path));
+        $newLocation = $this->applyPathPrefix($this->encodePath($newpath));
 
         try {
             $response = $this->client->request('MOVE', '/'.ltrim($location, '/'), null, [
@@ -158,7 +174,7 @@ class WebDAVAdapter extends AbstractAdapter
      */
     public function delete($path)
     {
-        $location = $this->applyPathPrefix($path);
+        $location = $this->applyPathPrefix($this->encodePath($path));
 
         try {
             $this->client->request('DELETE', $location);
@@ -174,7 +190,7 @@ class WebDAVAdapter extends AbstractAdapter
      */
     public function createDir($path, Config $config)
     {
-        $location = $this->applyPathPrefix($path);
+        $location = $this->applyPathPrefix($this->encodePath($path));
         $response = $this->client->request('MKCOL', $location);
 
         if ($response['statusCode'] !== 201) {
@@ -197,7 +213,7 @@ class WebDAVAdapter extends AbstractAdapter
      */
     public function listContents($directory = '', $recursive = false)
     {
-        $location = $this->applyPathPrefix($directory);
+        $location = $this->applyPathPrefix($this->encodePath($directory));
         $response = $this->client->propFind($location . '/', [
             '{DAV:}displayname',
             '{DAV:}getcontentlength',
@@ -209,7 +225,7 @@ class WebDAVAdapter extends AbstractAdapter
         $result = [];
 
         foreach ($response as $path => $object) {
-            $path = $this->removePathPrefix($path);
+            $path = urldecode($this->removePathPrefix($path));
             $object = $this->normalizeObject($object, $path);
             $result[] = $object;
 
@@ -217,7 +233,7 @@ class WebDAVAdapter extends AbstractAdapter
                 $result = array_merge($result, $this->listContents($object['path'], true));
             }
         }
-
+		
         return $result;
     }
 

--- a/src/WebDAVAdapter.php
+++ b/src/WebDAVAdapter.php
@@ -13,7 +13,7 @@ use Sabre\DAV\Client;
 use Sabre\DAV\Exception;
 use Sabre\DAV\Exception\NotFound;
 
-class WebDAVAdapterx extends AbstractAdapter
+class WebDAVAdapter extends AbstractAdapter
 {
     use StreamedTrait;
     use StreamedCopyTrait;
@@ -233,7 +233,7 @@ class WebDAVAdapterx extends AbstractAdapter
                 $result = array_merge($result, $this->listContents($object['path'], true));
             }
         }
-		
+
         return $result;
     }
 


### PR DESCRIPTION
WebDAV adapter works with url encoded names, when other adapters use plain names, for example, a file named "new file àéïôù.txt" is returned as "new%20file%20%C3%A0%C3%A9%C3%AF%C3%B4%C3%B9.txt". Actions also depend on url encoded paths.

Now, real names are returned and expected for actions.

Tested on owncloud WebDAV