### PR TITLE
Improved Folder detection

### DIFF
--- a/src/WebDAVAdapter.php
+++ b/src/WebDAVAdapter.php
@@ -271,7 +271,7 @@ class WebDAVAdapter extends AbstractAdapter
      */
     protected function normalizeObject(array $object, $path)
     {
-        if (! isset($object['{DAV:}getcontentlength'])) {
+        if (! isset($object['{DAV:}getcontentlength']) or $object['{DAV:}getcontentlength'] == "") {
             return ['type' => 'dir', 'path' => trim($path, '/')];
         }
 


### PR DESCRIPTION
There are certain WebDAV implementations (e.g. Novell Filr) that send an empty string for getcontentlength when the object is a folder.