### PR TITLE
Bugfix: Directory checking for debian-based webdav filesystems

### DIFF
--- a/src/WebDAVAdapter.php
+++ b/src/WebDAVAdapter.php
@@ -275,7 +275,14 @@ class WebDAVAdapter extends AbstractAdapter
      */
     protected function normalizeObject(array $object, $path)
     {
-        if (! isset($object['{DAV:}getcontentlength']) or $object['{DAV:}getcontentlength'] == "") {
+        $hasNotContentLength = !isset($object['{DAV:}getcontentlength']) ||
+            $object['{DAV:}getcontentlength'] == "";
+
+        $isDir = $hasNotContentLength || isset($object['{DAV:}resourcetype']) &&
+            $object['{DAV:}resourcetype'] instanceof ResourceType &&
+            $object['{DAV:}resourcetype']->is('{DAV:}collection');
+
+        if ($isDir) {
             return ['type' => 'dir', 'path' => trim($path, '/')];
         }
 


### PR DESCRIPTION
`ext-N` filesystems returns `{DAV:}getcontentlength` for all directories, around 4kb (4096b).

> /$ ls -la
> drwxr-xr-x 3 www-data www-data 4096 Sep 13 14:58 .
> drwxr-xr-x 7 www-data www-data 4096 Sep 13 14:58 ..
> -rw-rw-r-- 1 www-data www-data  110 Sep 13 14:58 README.txt
> drwxr-xr-x 2 www-data www-data 4096 Sep 13 14:58 src

This will be fix this bug
