### PR TITLE
check for directory using DAV:iscollection

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "php": ">=5.5.0",
+        "php": ">=5.6.0",
         "league/flysystem": "~1.0",
         "sabre/dav": "~3.1"
     },

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "php": ">=5.6.0",
+        "php": ">=5.5.0",
         "league/flysystem": "~1.0",
         "sabre/dav": "~3.1"
     },

--- a/src/WebDAVAdapter.php
+++ b/src/WebDAVAdapter.php
@@ -12,23 +12,23 @@ use LogicException;
 use Sabre\DAV\Client;
 use Sabre\DAV\Exception;
 use Sabre\DAV\Exception\NotFound;
-use Sabre\HTTP\ClientHttpException;
 use Sabre\HTTP\HttpException;
 
 class WebDAVAdapter extends AbstractAdapter
 {
-    const METADATA_FIELDS = [
+    use StreamedTrait;
+    use StreamedCopyTrait {
+        StreamedCopyTrait::copy as streamedCopy;
+    }
+    use NotSupportingVisibilityTrait;
+
+    private static $metadataFields = [
         '{DAV:}displayname',
         '{DAV:}getcontentlength',
         '{DAV:}getcontenttype',
         '{DAV:}getlastmodified',
         '{DAV:}iscollection',
     ];
-    use StreamedTrait;
-    use StreamedCopyTrait {
-        StreamedCopyTrait::copy as streamedCopy;
-    }
-    use NotSupportingVisibilityTrait;
 
     /**
      * @var array
@@ -88,7 +88,7 @@ class WebDAVAdapter extends AbstractAdapter
         $location = $this->applyPathPrefix($this->encodePath($path));
 
         try {
-            $result = $this->client->propFind($location, self::METADATA_FIELDS);
+            $result = $this->client->propFind($location, self::$metadataFields);
 
             return $this->normalizeObject($result, $path);
         } catch (Exception $e) {
@@ -262,7 +262,7 @@ class WebDAVAdapter extends AbstractAdapter
     public function listContents($directory = '', $recursive = false)
     {
         $location = $this->applyPathPrefix($this->encodePath($directory));
-        $response = $this->client->propFind($location . '/', self::METADATA_FIELDS, 1);
+        $response = $this->client->propFind($location . '/', self::$metadataFields, 1);
 
         array_shift($response);
         $result = [];

--- a/tests/WebDAVTests.php
+++ b/tests/WebDAVTests.php
@@ -154,15 +154,20 @@ class WebDAVTests extends PHPUnit_Framework_TestCase
         $first = [
             [],
             'filename' => [
-                '{DAV:}getcontentlength' => 20,
+                '{DAV:}getcontentlength' => "20",
+                '{DAV:}iscollection' => "0",
             ],
-            'dirname' => [],
+            'dirname' => [
+                '{DAV:}getcontentlength' => "0",
+                '{DAV:}iscollection' => "1",
+            ],
         ];
 
         $second = [
             [],
             'deeper_filename.ext' => [
-                '{DAV:}getcontentlength' => 20,
+                '{DAV:}getcontentlength' => "20",
+                '{DAV:}iscollection' => "0",
             ],
         ];
         $mock->shouldReceive('propFind')->twice()->andReturn($first, $second);


### PR DESCRIPTION
The current check for directory, which thinks an item is a directory if the content-length is empty of 0, is error-prone and fails on my IIS server where the client returns a string "0" for directories. It may also fail if there is an empty file in the directory.

This fix properly checks for a directory using DAV:iscollection.