### PR TITLE
add URL generation for WebDAV adapter

### DIFF
--- a/src/WebDAVAdapter.php
+++ b/src/WebDAVAdapter.php
@@ -44,6 +44,11 @@ class WebDAVAdapter extends AbstractAdapter
     protected $useStreamedCopy = true;
 
     /**
+     * @var string|null;
+     */
+    private $urlPrefix = null;
+
+    /**
      * Constructor.
      *
      * @param Client $client
@@ -380,5 +385,41 @@ class WebDAVAdapter extends AbstractAdapter
         $result['path'] = trim($path, '/');
 
         return $result;
+    }
+
+    /**
+     * Get the URL for the file at the given path.
+     *
+     * @param  string  $path
+     * @return string
+     */
+    public function getUrl($path)
+    {
+        $prefix = $this->getUrlPrefix();
+        return $prefix !== null
+            ? rtrim($prefix, '/') . '/' . ltrim($path, '/')
+            : $this->client->getAbsoluteUrl($path);
+    }
+
+    /**
+     * Get the custom URL prefix for URL generation
+     *
+     * @return string|null
+     */
+    public function getUrlPrefix()
+    {
+        return $this->urlPrefix;
+    }
+
+    /**
+     * Set the custom URL prefix for URL generation.
+     *
+     * If the prefix is not set, the baseUri of DAV client is used.
+     *
+     * @param string|null $prefix
+     */
+    public function setUrlPrefix($prefix)
+    {
+        $this->urlPrefix = $prefix;
     }
 }

--- a/tests/WebDAVTests.php
+++ b/tests/WebDAVTests.php
@@ -359,4 +359,30 @@ class WebDAVTests extends PHPUnit_Framework_TestCase
         $result = $adapter->copy('file.txt', 'newFile.txt');
         $this->assertTrue($result);
     }
+
+    public function testGetUrl()
+    {
+        /** @var Sabre\DAV\Client|Mockery\Mock $clientMock */
+        $clientMock = $this->getClient();
+
+        $url = 'http://webdav.local/prefix/newFile.txt';
+        $clientMock->shouldReceive('getAbsoluteUrl')->andReturn($url);
+
+        $adapter = new WebDAVAdapter($clientMock, 'prefix');
+        $result = $adapter->getUrl('newFile.txt');
+        $this->assertEquals($url, $result);
+    }
+
+    public function testGetUrlWithCustomPrefix()
+    {
+        /** @var Sabre\DAV\Client|Mockery\Mock $clientMock */
+        $clientMock = $this->getClient();
+
+        $clientMock->shouldReceive('getAbsoluteUrl')->andReturn('http://webdav.local/prefix/newFile.txt');
+
+        $adapter = new WebDAVAdapter($clientMock, 'prefix');
+        $adapter->setUrlPrefix('https://cdn.local');
+        $result = $adapter->getUrl('newFile.txt');
+        $this->assertEquals('https://cdn.local/newFile.txt', $result);
+    }
 }


### PR DESCRIPTION
This pull request adds URL generation for the adapter, which is then usable in Laravel storage to automatically generate URL for the files inside the WebDAV storage.

By default, the URL generated is exactly the same as the URL used by the DAV client, however, it can be changed by calling setUrlPrefix(), for example, to a reverse proxy or some sort of CDN.