### PR TITLE
Flysystem::rename('sample.txt', 'renamed.txt');

### DIFF
--- a/src/WebDAVAdapter.php
+++ b/src/WebDAVAdapter.php
@@ -173,7 +173,7 @@ class WebDAVAdapter extends AbstractAdapter
 
         try {
             $response = $this->client->request('MOVE', '/'.ltrim($location, '/'), null, [
-                'Destination' => '/'.ltrim($newLocation, '/'),
+                'Destination' => $this->client->getAbsoluteUrl(ltrim($newLocation,'/'))
             ]);
 
             if ($response['statusCode'] >= 200 && $response['statusCode'] < 300) {


### PR DESCRIPTION
https://github.com/thephpleague/flysystem-webdav/issues/27
$rename = Flysystem::rename('sample.txt', 'renamed.txt');
It does not work for me. All the other methods are fine.
Apache log:
AH00592: Destination URI must be an absolute URI.
I use WebDav connection.

UPDATE 1:
I have changed: vendor/league/flysystem-webdav/src/WebDAVAdapter.php
line 178
from 'Destination' => '/'.ltrim($newLocation, '/'),
to 'Destination' => $this->client->getAbsoluteUrl(ltrim($newLocation,'/'))
IT WORKS!