### PR TITLE
fix streamed writing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ bin
 coverage
 coverage.xml
 composer.lock
+.DS_Store
+.idea/
+phpunit.xml

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -23,7 +23,4 @@
     <listeners>
         <listener class="Mockery\Adapter\Phpunit\TestListener" file="./vendor/mockery/mockery/library/Mockery/Adapter/Phpunit/TestListener.php"></listener>
     </listeners>
-    <php>
-        <ini name="memory_limit" value="8M"/>
-    </php>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -23,4 +23,7 @@
     <listeners>
         <listener class="Mockery\Adapter\Phpunit\TestListener" file="./vendor/mockery/mockery/library/Mockery/Adapter/Phpunit/TestListener.php"></listener>
     </listeners>
+    <php>
+        <ini name="memory_limit" value="8M"/>
+    </php>
 </phpunit>

--- a/src/WebDAVAdapter.php
+++ b/src/WebDAVAdapter.php
@@ -5,7 +5,7 @@ namespace League\Flysystem\WebDAV;
 use League\Flysystem\Adapter\AbstractAdapter;
 use League\Flysystem\Adapter\Polyfill\NotSupportingVisibilityTrait;
 use League\Flysystem\Adapter\Polyfill\StreamedCopyTrait;
-use League\Flysystem\Adapter\Polyfill\StreamedTrait;
+use League\Flysystem\Adapter\Polyfill\StreamedReadingTrait;
 use League\Flysystem\Config;
 use League\Flysystem\Util;
 use LogicException;
@@ -17,7 +17,7 @@ use Sabre\HTTP\HttpException;
 
 class WebDAVAdapter extends AbstractAdapter
 {
-    use StreamedTrait;
+    use StreamedReadingTrait;
     use StreamedCopyTrait {
         StreamedCopyTrait::copy as streamedCopy;
     }
@@ -158,9 +158,25 @@ class WebDAVAdapter extends AbstractAdapter
     /**
      * {@inheritdoc}
      */
+    public function writeStream($path, $resource, Config $config)
+    {
+        return $this->write($path, $resource, $config);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function update($path, $contents, Config $config)
     {
         return $this->write($path, $contents, $config);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function updateStream($path, $resource, Config $config)
+    {
+        return $this->update($path, $resource, $config);
     }
 
     /**


### PR DESCRIPTION
## SUMMARY

Fix memory limit issue on large file uploading (#28, #34)

## DESCRIPTION

The current implementation uses League\Flysystem\Adapter\Polyfill\StreamedWritingTrait, which reads the whole contents of a given stream into variable and consumes memory for the size of the file.

However, Sabre\DAV\Client::request() can give a stream resource to the body parameter.

Instead of using StreamedWritingTrait, I created writeStream and updateStream functions so that streamed uploading is done without reading the file contents into variables.