### PR TITLE
Directories with a plus (+) in their name have it removed

### DIFF
--- a/src/WebDAVAdapter.php
+++ b/src/WebDAVAdapter.php
@@ -289,7 +289,7 @@ class WebDAVAdapter extends AbstractAdapter
         $result = [];
 
         foreach ($response as $path => $object) {
-            $path = urldecode($this->removePathPrefix($path));
+            $path = rawurldecode($this->removePathPrefix($path));
             $object = $this->normalizeObject($object, $path);
             $result[] = $object;
 

--- a/tests/WebDAVTests.php
+++ b/tests/WebDAVTests.php
@@ -231,6 +231,25 @@ class WebDAVTests extends PHPUnit_Framework_TestCase
         $this->assertInternalType('array', $listing);
     }
 
+    public function testListContentsWithPlusInName()
+    {
+        $mock = $this->getClient();
+        $first = [
+            [],
+            'bucketname/dirname+something' => [
+                '{DAV:}getcontentlength' => "0",
+                '{DAV:}iscollection' => "1",
+            ],
+        ];
+
+        $mock->shouldReceive('propFind')->once()->andReturn($first);
+        $adapter = new WebDAVAdapter($mock, 'bucketname');
+        $listing = $adapter->listContents('', false);
+        $this->assertInternalType('array', $listing);
+        $this->assertCount(1, $listing);
+        $this->assertEquals('dirname+something', $listing[0]['path']);
+    }
+
     public function methodProvider()
     {
         return [


### PR DESCRIPTION
This makes it impossible to work with such directory entries.

Using rawurldecode does the same as urldecode but it keeps the valid + signs