### PR TITLE
Collections should be created with a slash at the end.

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,6 +10,10 @@
          stopOnFailure="true"
          syntaxCheck="true"
 >
+    <php>
+        <ini name="memory_limit" value="128M" />
+    </php>
+
     <testsuites>
         <testsuite name="flysystem/gridfs/tests">
             <directory suffix=".php">./tests/</directory>

--- a/src/WebDAVAdapter.php
+++ b/src/WebDAVAdapter.php
@@ -260,7 +260,7 @@ class WebDAVAdapter extends AbstractAdapter
         }
 
         $location = $this->applyPathPrefix($encodedPath);
-        $response = $this->client->request('MKCOL', $location);
+        $response = $this->client->request('MKCOL', $location . $this->pathSeparator);
 
         if ($response['statusCode'] !== 201) {
             return false;

--- a/tests/WebDAVTests.php
+++ b/tests/WebDAVTests.php
@@ -269,7 +269,7 @@ class WebDAVTests extends PHPUnit_Framework_TestCase
 
         $mock->shouldReceive('request')
             ->once()
-            ->with('MKCOL', 'dirname')
+            ->with('MKCOL', 'dirname/')
             ->andReturn([
                 'statusCode' => 201,
             ]);
@@ -290,14 +290,14 @@ class WebDAVTests extends PHPUnit_Framework_TestCase
 
         $mock->shouldReceive('request')
             ->once()
-            ->with('MKCOL', 'dirname')
+            ->with('MKCOL', 'dirname/')
             ->andReturn([
                 'statusCode' => 201,
             ]);
 
         $mock->shouldReceive('request')
             ->once()
-            ->with('MKCOL', 'dirname/subdirname')
+            ->with('MKCOL', 'dirname/subdirname/')
             ->andReturn([
                 'statusCode' => 201,
             ]);
@@ -340,7 +340,7 @@ class WebDAVTests extends PHPUnit_Framework_TestCase
 
         $mock->shouldReceive('request')
             ->once()
-            ->with('MKCOL', 'dirname')
+            ->with('MKCOL', 'dirname/')
             ->andReturn([
                 'statusCode' => 500,
             ]);


### PR DESCRIPTION
Omitting trailing slash at least with Nginx leads to "MKCOL can create a
collection only" error.

See also:
- https://tools.ietf.org/html/rfc4918#section-9.3
- https://github.com/thephpleague/flysystem/issues/957
- https://github.com/thephpleague/flysystem-webdav/pull/43