### PR TITLE
Make $metadataFields and isDirectory protected instead of private.

### DIFF
--- a/src/WebDAVAdapter.php
+++ b/src/WebDAVAdapter.php
@@ -22,7 +22,7 @@ class WebDAVAdapter extends AbstractAdapter
     }
     use NotSupportingVisibilityTrait;
 
-    private static $metadataFields = [
+    protected static $metadataFields = [
         '{DAV:}displayname',
         '{DAV:}getcontentlength',
         '{DAV:}getcontenttype',
@@ -88,7 +88,7 @@ class WebDAVAdapter extends AbstractAdapter
         $location = $this->applyPathPrefix($this->encodePath($path));
 
         try {
-            $result = $this->client->propFind($location, self::$metadataFields);
+            $result = $this->client->propFind($location, static::$metadataFields);
 
             if (empty($result)) {
                 return false;
@@ -283,7 +283,7 @@ class WebDAVAdapter extends AbstractAdapter
     public function listContents($directory = '', $recursive = false)
     {
         $location = $this->applyPathPrefix($this->encodePath($directory));
-        $response = $this->client->propFind($location . '/', self::$metadataFields, 1);
+        $response = $this->client->propFind($location . '/', static::$metadataFields, 1);
 
         array_shift($response);
         $result = [];
@@ -400,7 +400,7 @@ class WebDAVAdapter extends AbstractAdapter
         return $result;
     }
 
-    private function isDirectory(array $object)
+    protected function isDirectory(array $object)
     {
         return isset($object['{DAV:}iscollection']) && $object['{DAV:}iscollection'] === '1';
     }


### PR DESCRIPTION
This will allow extending the adapter if needed to support different flavours of WebDAV. I recently needed to support NextCloud, for which it was impossible to distinguish files from directories using the default WebDAV adapter. 