### PR TITLE
[listContents] Fixed rawurldecode order

### DIFF
--- a/src/WebDAVAdapter.php
+++ b/src/WebDAVAdapter.php
@@ -289,7 +289,7 @@ class WebDAVAdapter extends AbstractAdapter
         $result = [];
 
         foreach ($response as $path => $object) {
-            $path = rawurldecode($this->removePathPrefix($path));
+            $path = $this->removePathPrefix(rawurldecode($path));
             $object = $this->normalizeObject($object, $path);
             $result[] = $object;
 

--- a/tests/WebDAVTests.php
+++ b/tests/WebDAVTests.php
@@ -250,6 +250,27 @@ class WebDAVTests extends PHPUnit_Framework_TestCase
         $this->assertEquals('dirname+something', $listing[0]['path']);
     }
 
+    public function testListContentsWithUrlEncodedSpaceInName()
+    {
+        $mock = $this->getClient();
+        $first = [
+            [],
+            '/My%20Library/New%20Record%201.mp3' => [
+                '{DAV:}displayname' => "New Record 1.mp3",
+                '{DAV:}getcontentlength' => "8223370",
+            ],
+        ];
+
+        $mock->shouldReceive('propFind')->once()->andReturn($first);
+        $adapter = new WebDAVAdapter($mock, '/My Library');
+        $listing = $adapter->listContents('', false);
+        $this->assertInternalType('array', $listing);
+        $this->assertCount(1, $listing);
+        $this->assertEquals('New Record 1.mp3', $listing[0]['path']);
+        $this->assertEquals('file', $listing[0]['type']);
+        $this->assertEquals('8223370', $listing[0]['size']);
+    }
+
     public function methodProvider()
     {
         return [


### PR DESCRIPTION
Hello. While integrating this plugin with Seafile Webdav I encountered a bug in [this line](https://github.com/thephpleague/flysystem-webdav/blob/1.0.6/src/WebDAVAdapter.php#L292):
```
$path = rawurldecode($this->removePathPrefix($path));
```
So removePathPrefix was trying to remove the prefix from `/My%20Library/New%20Record%201.mp3` based on the length of `/My Library`. The result was `y/New Record 1.mp3` instead of `New Record 1.mp3`.
Because the path was decoded too late. Here is the fix covered with unit test.