### PR TITLE
Update minimal php and sabre/dav versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,10 @@ services:
 language: php
 
 php:
-  - 5.6
   - 7.0
   - 7.1
   - 7.2
+  - 7.3
 
 install:
   - travis_retry composer install --no-interaction --prefer-source

--- a/composer.json
+++ b/composer.json
@@ -9,13 +9,13 @@
         }
     ],
     "require": {
-        "php": ">=5.5.0",
+        "php": ">=7.0 <7.4",
         "league/flysystem": "~1.0",
-        "sabre/dav": "~3.1"
+        "sabre/dav": "~4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.0",
-        "mockery/mockery": "~0.9"
+        "phpunit/phpunit": "~6.5",
+        "mockery/mockery": "~1.2"
     },
     "autoload": {
         "psr-4": {

--- a/tests/WebDAVTests.php
+++ b/tests/WebDAVTests.php
@@ -3,9 +3,12 @@
 use League\Flysystem\Config;
 use League\Flysystem\Filesystem;
 use League\Flysystem\WebDAV\WebDAVAdapter;
+use PHPUnit\Framework\TestCase;
 
-class WebDAVTests extends PHPUnit_Framework_TestCase
+class WebDAVTests extends TestCase
 {
+    use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+
     protected function getClient()
     {
         return Mockery::mock('Sabre\DAV\Client');


### PR DESCRIPTION
sabre/dav 3.x requires legacy sabre/http package with at least one [critical bug](https://github.com/sabre-io/http/issues/89).

Actual 4.0.2 package requires php >= 7.

PHP 7.4 brakes on \Sabre\DAV\Client::request.