### PR TITLE
Remove path prefix only if $path contains prefix

### DIFF
--- a/src/WebDAVAdapter.php
+++ b/src/WebDAVAdapter.php
@@ -291,7 +291,11 @@ class WebDAVAdapter extends AbstractAdapter
         $result = [];
 
         foreach ($response as $path => $object) {
-            $path = $this->removePathPrefix(rawurldecode($path));
+            //Remove path prefix only if $path contains prefix
+            if (strpos($path, $this->getPathPrefix()) === 0) {
+                $path = $this->removePathPrefix(rawurldecode($path));
+            }
+
             $object = $this->normalizeObject($object, $path);
             $result[] = $object;
 


### PR DESCRIPTION
I am testing a webdav implementation with Nginx on Debian 10. I have encountered an error trying to list the contents of a directory. The problem is that in the `listContents` function it removes as many characters as the prefix of the path, even if the path returned by the webdav server does not contain the prefix. This causes the necessary part of the returned file paths to be removed.

In my case the following happened:
Prefix: `http://192.168.0.103:20000/`
Route returned by webdav: `/uploads/user/8546/2020-06-12`
Result: `06-12`